### PR TITLE
Refactor: Extract ProductItem types to separate file

### DIFF
--- a/src/components/molecules/productItem/index.tsx
+++ b/src/components/molecules/productItem/index.tsx
@@ -1,13 +1,6 @@
 import Image from "next/image";
 import { Button } from "@/components/molecules/button";
-import { Game } from "@/types/game";
-
-export interface ProductItemProps {
-  game: Game;
-  handleOnClick: () => void;
-  isInCart: boolean;
-  isLoading: boolean;
-}
+import { ProductItemProps } from "./types";
 
 export const ProductItem = ({
   game,

--- a/src/components/molecules/productItem/types.ts
+++ b/src/components/molecules/productItem/types.ts
@@ -1,0 +1,8 @@
+import { Game } from "@/types/game";
+
+export interface ProductItemProps {
+  game: Game;
+  handleOnClick: () => void;
+  isInCart: boolean;
+  isLoading: boolean;
+}


### PR DESCRIPTION
Extracted ProductItemProps interface from the main ProductItem component to a dedicated types file to improve code organization and maintainability.

### Changes
- Created new `types.ts` file in `src/components/molecules/productItem/`
- Moved `ProductItemProps` interface to the dedicated types file
- Updated import statement in ProductItem component